### PR TITLE
Facet BMI and weight by row

### DIFF
--- a/R/data-analysis/plot_current_summary_stats.R
+++ b/R/data-analysis/plot_current_summary_stats.R
@@ -43,7 +43,7 @@ plot_current_summary_stats <- function(data, strata = "Overall"){
       geom_errorbarh(aes(xmin = q1, xmax = q3), height = 0, color = "darkblue", linewidth = 0.5) +
       geom_point(aes(x = median), color = "darkblue", size = 3) +
       geom_point(aes(x = mean), color = "darkred", size = 3, shape = 4, stroke = 1) +
-      facet_wrap(~variable, nrow = 1, scales = "free", labeller = label_wrap_gen(width = 25)) +
+      facet_wrap(~variable, nrow = 2, scales = "free", labeller = label_wrap_gen(width = 25)) +
       labs(x = "Value",
            caption = "Blue point = median; X = mean; blue line = IQR") +
       #theme_bw() +

--- a/R/data-analysis/plot_time_series_statistics.R
+++ b/R/data-analysis/plot_time_series_statistics.R
@@ -47,7 +47,7 @@ plot_time_series_statistics <- function(data, strata = "Overall"){
       geom_ribbon(aes(ymin = q1, ymax = q3,  fill = "IQR"), alpha = 0.2, linetype = 0) +
       scale_colour_manual(values = c("Mean" = "darkred", "Median" = "darkblue")) +
       scale_fill_manual(values = c("IQR" = "darkblue")) +
-      facet_wrap(~variable, ncol = 1, scales = "free_y") +
+      facet_wrap(~variable, ncol = 2, scales = "free_y") +
       labs(x = "Date", y = "Value") +
       theme(axis.text.x = element_text(angle = 45, hjust = 1, vjust = 1),
             legend.title     = element_blank(),


### PR DESCRIPTION
Suggesting to facet the plots so that we show BMI (total and change for BMI and weight on separate rows/columns. This barely changes the code but is a quick win for easier interpreting I think, as the two indicators are not really comparable / in different units so it's a bit confusing to have them on an equal meta-axis.