### PR TITLE
drop % weight change from current summary plot

### DIFF
--- a/R/data-analysis/plot_current_summary_stats.R
+++ b/R/data-analysis/plot_current_summary_stats.R
@@ -29,12 +29,16 @@ pacman::p_load(
 
 plot_current_summary_stats <- function(data, strata = "Overall"){
 
+  variables <- c("bmi_percent_change_prewar",
+                 "bmi",
+                 "weight")
+
   # Filter data for the selected option
   data_filter <- data[[tolower(strata)]] |>
     filter(date == max(date, na.rm = TRUE)) %>%
     pivot_wider(names_from = stat, values_from = value) %>%
     dplyr::filter(!is.na(mean)) |>
-    filter(!grepl("_firstmeasurement", variable))
+    filter(variable %in% variables)
 
   data_filter <- recode_data_table(data_filter)
 


### PR DESCRIPTION
I think we should drop the "% change weight from prewar" plots - they are identical to the % change in BMI, as height doesn't change.

What we did made sense originally as in the first iteration, we were showing BMI and weight in separate tabs. But as we are now plotting weight and BMI side by side, it doesn't make too much sense to have 2 identical plots. It would free up a lot of space. We can reinstate if we change the layout later as the variable is still in the data.