### PR TITLE
Test and improve pipeline for current summary + minor fixes/clarifications

### DIFF
--- a/R/data-analysis/generate_key_insights.R
+++ b/R/data-analysis/generate_key_insights.R
@@ -15,18 +15,24 @@
 #...............................................................................
 
 
-generate_key_insights <- function(data) {
+generate_key_insights <- function(data, strata) {
+  data <- data[[tolower(strata)]]
+  data <- filter(data, variable == "weight_percent_change_prewar")
   params <- list(
     # Most recent date
-    latest_date = max(data$overall$date),
+    latest_date = data$current_summary_date[1],
     # N
-    cohort_size = max(data$overall$cohort_n),
+    cohort_size_current = max(data$cohort_id_enrolled, na.rm=TRUE),
+    cohort_size_alltime = max(data$cohort_id_enrolled_alltime, na.rm=TRUE),
     # Observations
-    observations = sum(distinct(filter(data$overall, variable == "weight" & stat == "mean"))$cohort_recorded),
+    observations = sum(distinct(filter(data, stat == "mean"))$cohort_obs_recorded),
 
-    median_change = round(filter(data$overall, date == max(date) & variable == "weight_percent_change_prewar" & stat == "median")$value, 2)
-
+    median_change = round(filter(data, stat == "median")$value, 1),
+    upper_change = round(filter(data, stat == "q3")$value, 1),
+    lower_change = round(filter(data, stat == "q1")$value, 1)
   )
+  params$cohort_percent_currently_participating <- params$cohort_size_current /
+    params$cohort_size_alltime * 100
+
   return(params)
 }
-

--- a/R/data-analysis/plot_current_summary_stats.R
+++ b/R/data-analysis/plot_current_summary_stats.R
@@ -31,7 +31,6 @@ plot_current_summary_stats <- function(data, strata = "Overall"){
 
   # Filter data for the selected option
   data_filter <- data[[tolower(strata)]] |>
-    filter(date == max(date, na.rm = TRUE)) %>%
     pivot_wider(names_from = stat, values_from = value) %>%
     dplyr::filter(!is.na(mean)) |>
     filter(!grepl("_firstmeasurement", variable))

--- a/R/data-analysis/plot_participants_over_time.R
+++ b/R/data-analysis/plot_participants_over_time.R
@@ -40,7 +40,7 @@ plot_participants_over_time <- function(data, strata = "Overall"){
     # Generate plot
     fig <- data_filter %>%
       ggplot() +
-      geom_area(aes(x = date, y = cohort_n, fill = label, group = label),
+      geom_area(aes(x = date, y = cohort_id_enrolled, fill = label, group = label),
                 position = "stack", alpha = 0.8, show.legend = F) +
       labs(x = "Date",
            y = "Participants",
@@ -53,7 +53,7 @@ plot_participants_over_time <- function(data, strata = "Overall"){
   else {
     fig <- data_filter %>%
       ggplot() +
-      geom_area(aes(x = date, y = cohort_n, fill = label, group = label),
+      geom_area(aes(x = date, y = cohort_id_enrolled, fill = label, group = label),
                 position = "stack", alpha = 0.8) +
       labs(x = "Date",
            y = "Participants",

--- a/R/data-pipeline/1-data_cleaning.R
+++ b/R/data-pipeline/1-data_cleaning.R
@@ -82,7 +82,10 @@ clean_data <- function(base_data, fup_data) {
                                         weight_prewar)*100,
       bmi_percent_change_prewar = ((bmi - bmi_prewar)/
                                      bmi_prewar)*100) |>
-    ungroup()
+    ungroup() |>
+    # drop 0 percent change on date of first measurement
+    mutate(across(contains("_percent_change_firstmeasurement"),
+           ~ ifelse(date == date_first_measurement, NA, .x)))
 
  change_from_previous <- matched_data %>%
     dplyr::arrange(id, date) %>%

--- a/R/data-pipeline/1-data_cleaning.R
+++ b/R/data-pipeline/1-data_cleaning.R
@@ -139,7 +139,7 @@ clean_data <- function(base_data, fup_data) {
   # Flag anomalous data
   matched_data <- matched_data |>
     mutate(
-      observation_valid = case_when(
+      weight_anomaly = case_when(
         !between(bmi, 10, 60) ~ FALSE,
         weight_percent_change_previousmeasurement >= 10 ~ FALSE,
         TRUE ~ TRUE)

--- a/R/data-pipeline/1-data_cleaning.R
+++ b/R/data-pipeline/1-data_cleaning.R
@@ -66,10 +66,10 @@ clean_data <- function(base_data, fup_data) {
   matched_data <- matched_data |>
     group_by(id) |>
     dplyr::mutate(
-      # daily absolute number
+      # BMI
       bmi = weight / (height/100)^2,
       bmi_prewar = weight_prewar / (height/100)^2,
-      # prewar absolute
+      # enrolment value
       first_weight_measurement = weight[date == date_first_measurement],
       first_bmi_measurement = bmi[date == date_first_measurement],
       # change since enrolment
@@ -148,17 +148,6 @@ clean_data <- function(base_data, fup_data) {
   # add "overall" variable for total-cohort summaries
   matched_data <- matched_data |>
     mutate(overall = "overall")
-
-  # Data quality checks -----------------------------------------------------
-
-  # Flag anomalous data
-  matched_data <- matched_data |>
-    mutate(
-      weight_anomaly = case_when(
-        !between(bmi, 10, 60) ~ FALSE,
-        weight_percent_change_previousmeasurement >= 10 ~ FALSE,
-        TRUE ~ TRUE)
-    )
 
   matched_data <- ungroup(matched_data)
 

--- a/R/data-pipeline/1-data_cleaning.R
+++ b/R/data-pipeline/1-data_cleaning.R
@@ -104,6 +104,21 @@ clean_data <- function(base_data, fup_data) {
   matched_data <- left_join(matched_data,
                             change_from_previous, by = c("id", "date"))
 
+  # Data quality checks -----------------------------------------------------
+  # Flag anomalous data
+  matched_data <- matched_data |>
+    mutate(
+      weight_anomaly = case_when(
+        !between(bmi, 10, 60) ~ TRUE,
+        weight_percent_change_previousmeasurement >= 10 ~ TRUE,
+        TRUE ~ FALSE)
+    )
+  # Set anomalous data to NA
+  matched_data <- matched_data |>
+    mutate(across(contains(c("weight", "bmi")),
+                  ~ ifelse(weight_anomaly, NA, .x)))
+
+
   # Specify factor variables ------------------------------------------------
   # TODO use data dictionary here
   matched_data <- matched_data |>

--- a/R/data-pipeline/2-data_aggregation.R
+++ b/R/data-pipeline/2-data_aggregation.R
@@ -15,6 +15,13 @@ summarise_ids <- function(data, group_cols) {
   df_participants <- data |>
     group_by(across(all_of(group_cols))) |>
     summarise(
+      # participants enrolled ---
+      cohort_id_enrolled = length(unique(id)),
+      # daily observations ---
+      # number of recorded weights, denominator: cohort_n
+      cohort_obs_recorded = sum(!is.na(weight)),
+      # missing weight among all enrolled, denominator: cohort_n
+      cohort_obs_missing = sum(is.na(weight)),
       # anomalous weight among recorded weights, denominator: cohort_obs_recorded
       cohort_obs_anomalous = sum(!weight_anomaly),
       .groups = "drop"
@@ -55,7 +62,6 @@ summarise_ids <- function(data, group_cols) {
                             all_of(c(group_cols, "cohort_recorded")))) |>
     mutate(value = count / cohort_recorded * 100,
            stat = "percent",
-           variable = paste0("bmi_category_", bmi_category)) |>
     ungroup() |>
     dplyr::select(all_of(c(group_cols, "value", "stat", "variable"))) |>
     complete(nesting(!!!syms(group_cols)), stat, variable, fill = list(value = 0))

--- a/R/data-pipeline/2-data_aggregation.R
+++ b/R/data-pipeline/2-data_aggregation.R
@@ -23,7 +23,7 @@ summarise_ids <- function(data, group_cols) {
       # missing weight among all enrolled, denominator: cohort_n
       cohort_obs_missing = sum(is.na(weight)),
       # anomalous weight among recorded weights, denominator: cohort_obs_recorded
-      cohort_obs_anomalous = sum(!weight_anomaly),
+      cohort_obs_anomalous = sum(weight_anomaly),
       .groups = "drop"
       )
 

--- a/R/data-pipeline/2-data_aggregation.R
+++ b/R/data-pipeline/2-data_aggregation.R
@@ -95,11 +95,10 @@ summarise_ids <- function(data, group_cols) {
 }
 
 clean_aggregated_data <- function(summary_list) {
-  # Restructuring into a list by organisation
+  # drop "other" sex category
   summary_df <- list_rbind(summary_list) |>
     ungroup()
 
-  # drop "other" sex category
   summary_df <- summary_df |>
     filter(!grepl("other/prefer not to share", sex))
 

--- a/R/data-pipeline/run-public-pipeline.R
+++ b/R/data-pipeline/run-public-pipeline.R
@@ -62,6 +62,16 @@ data_id_latest <- data_id |>
 data_id_dated <- bind_rows(data_id, data_id_latest)
 
 # summarise by date, organisation, and group -----
+
+# Create 2 levels of stratification
+group_cols <- c("agegroup", "children_feeding", "governorate", "role", "sex")
+group_cols <- combn(group_cols, 2, simplify = FALSE)
+group_cols <- append(group_cols, as.list(c("overall", "agegroup", "children_feeding", "governorate", "role", "sex")))
+group_cols <- append(map(group_cols,
+                         ~ c("date", "organisation", sort(.x))),
+                     map(group_cols,
+                         ~ c("date", sort(.x))))
+
 #' Do not print all messages when running on server
 if(interactive()){
   summary <- imap(group_cols,

--- a/R/data-pipeline/run-public-pipeline.R
+++ b/R/data-pipeline/run-public-pipeline.R
@@ -40,7 +40,9 @@ group_cols <- append(map(group_cols,
 # Current summary: use most recent observation from participants reporting in most recent x day window -----
 # TODO fix this very hacky code
 # TODO set this interactively so not fixed to now
-current_days <- seq.Date(Sys.Date() - 3, length.out = 4, by = "day")
+latest_date <- as.Date(max(data_id$date, na.rm = TRUE))
+recent_days <- seq.Date(from = latest_date - 3,
+                        length.out = 4, by = "day")
 
 # filter to current data
 data_id_latest <- data_id |>
@@ -49,7 +51,7 @@ data_id_latest <- data_id |>
     # only include observations that are recorded & in valid range
     observation_valid &
       # only within most recent window
-      date %in% current_days &
+      date %in% recent_days &
       # only latest for each participant
       date == max(date, na.rm = TRUE)) |>
   ungroup() |>

--- a/R/data-pipeline/run-public-pipeline.R
+++ b/R/data-pipeline/run-public-pipeline.R
@@ -11,7 +11,7 @@ if(interactive()) {
   base <- here("R", "data-pipeline")
 } else {
   base <- sprintf("%s/R/data-pipeline", .args["wd"]) #"https://raw.githubusercontent.com/cmmid/gaza-response/main/R/data-pipeline"
-  
+
   #do not show summarise message unless in interactive session
   options(dplyr.summarise.inform = FALSE)
 }
@@ -40,7 +40,7 @@ group_cols <- append(map(group_cols,
 # Current summary: use most recent observation from participants reporting in most recent x day window -----
 # TODO fix this very hacky code
 # TODO set this interactively so not fixed to now
-current_days <- seq.Date(Sys.Date() - 3, length.out = 3, by = "day")
+current_days <- seq.Date(Sys.Date() - 3, length.out = 4, by = "day")
 
 # filter to current data
 data_id_latest <- data_id |>
@@ -56,7 +56,7 @@ data_id_latest <- data_id |>
   # set date to the future to use as a flag that this is the most recent record (noting all group calculations include date so will not be double-counted)
   mutate(date = Sys.Date() + 3650)
 
-# bind latest data with fill time series
+# bind latest data with full time series
 data_id_dated <- bind_rows(data_id, data_id_latest)
 
 # summarise by date, organisation, and group -----

--- a/index.qmd
+++ b/index.qmd
@@ -100,15 +100,21 @@ We are actively seeking participants to support the project, and welcome new col
 
 ```{r filter_all, include=FALSE}
 data_filtered <- data$all
-params <- generate_key_insights(data_filtered)
+# split data into current 72h summary, or full timeseries
+data_filtered_current <- map(data_filtered,
+                             ~ filter(.x, is.na(date)))
+data_filtered_timeseries <- map(data_filtered,
+                             ~ filter(.x, !is.na(date)))
+
+params <- generate_key_insights(data_filtered_current, strata = "Overall") # TODO iterate over strata to match other chunks
 ```
 
 ## Row
 
 ::: {.card fill="false" title="Key insights"}
 - Data updated as of **`r params$latest_date`**
-- Collected  **`r params$observations` observations** from **`r params$cohort_size` participants**
-- Median change of **`r params$median_change`%** compared to pre-war weight
+- Recent data from **`r params$cohort_size_current` participants** (**`r params$cohort_percent_currently_participating`%** of all enrolled participants)
+- Median change of **`r params$median_change`%** compared to pre-war weight (with a typical range of `r params$lower_change`% to `r params$upper_change`%)
 :::
 
 ## Row
@@ -127,7 +133,7 @@ for(i in strata) {
   
   print(
     plot_current_summary_stats(
-      data = data_filtered,
+      data = data_filtered_current,
       strata = i
     )
   )
@@ -154,7 +160,7 @@ for(i in strata) {
   
   print(
    plot_time_series_statistics(
-      data = data_filtered,
+      data = data_filtered_timeseries,
       strata = i
     )
   )
@@ -181,7 +187,7 @@ for(i in strata) {
   
   print(
      plot_bmicategory_proportions_time_series(
-     data = data_filtered,
+     data = data_filtered_timeseries,
      strata = i
     )
   )
@@ -207,7 +213,7 @@ for(i in strata) {
   
   print(
     plot_participants_over_time(
-      data = data_filtered,
+      data = data_filtered_timeseries,
       strata = i
     )
   )
@@ -219,20 +225,26 @@ for(i in strata) {
 
 
 
-
+<!-- ------------------------ Organisation tabs --------------------------- -->
 
 
 # Save the Children International
 ```{r filter_stc, include=FALSE}
 data_filtered <- data$`Save the Children International`
-params <- generate_key_insights(data_filtered)
+# split data into current 72h summary, or full timeseries
+data_filtered_current <- map(data_filtered,
+                             ~ filter(.x, is.na(date)))
+data_filtered_timeseries <- map(data_filtered,
+                             ~ filter(.x, !is.na(date)))
+
+params <- generate_key_insights(data_filtered_current, strata = "Overall") # TODO iterate over strata to match other chunks
 ```
 
 
 ::: {.card fill="false" title="Key insights"}
 - Data updated as of **`r params$latest_date`**
-- Collected  **`r params$observations` observations** from **`r params$cohort_size` participants**
-- Median **`r params$median_change[1]`kg** change compared to pre-war weight
+- Recent data from **`r params$cohort_size_current` participants** (**`r params$cohort_percent_currently_participating`%** of all enrolled participants)
+- Median change of **`r params$median_change`%** compared to pre-war weight (with a typical range of `r params$lower_change`% to `r params$upper_change`%)
 :::
 
 
@@ -250,7 +262,7 @@ for(i in strata) {
   
   print(
     plot_current_summary_stats(
-      data = data_filtered,
+      data = data_filtered_current,
       strata = i
     )
   )
@@ -277,7 +289,7 @@ for(i in strata) {
   
   print(
     plot_time_series_statistics(
-      data = data_filtered,
+      data = data_filtered_timeseries,
       strata = i
     )
   )
@@ -304,7 +316,7 @@ for(i in strata) {
   
   print(
      plot_bmicategory_proportions_time_series(
-     data = data_filtered,
+     data = data_filtered_timeseries,
      strata = i
     )
   )
@@ -331,7 +343,7 @@ for(i in strata) {
   
   print(
     plot_participants_over_time(
-      data = data_filtered,
+      data = data_filtered_timeseries,
       strata = i
     )
   )


### PR DESCRIPTION
I went through the full pipeline and checked in detail that all calculations were performing correctly. 

My main concern was that the "current" summary statistics (latest obs over 72h) were at risk of being mixed up with the daily timeseries statistics, which they need to be separate from as they are calculated over different dates/participants. 

- I've made the separation between the two types of summary clearer in the variable names and the data pipeline throughout, and updated the downstream plotting and key insights code to reflect that. The rendered site now shows accurately.

Also:
- Fixed a problem with BMI category proportions, by avoiding duplicated code (for current / pre-war counts)
- Made small updates for clarity: observation_valid changed to weight_anomaly to indicate an anomalous observation
- Ensured anomalous observations are correctly removed from the data (set to NA and filtered out) before summaries calculated