### PR TITLE
[WIP] Dashboard layout update

### DIFF
--- a/R/data-analysis/generate_key_insights.R
+++ b/R/data-analysis/generate_key_insights.R
@@ -16,7 +16,7 @@
 
 
 generate_key_insights <- function(data, strata) {
-  data <- data[[tolower(strata)]]
+  data <- filter(data, group == strata)
   data <- filter(data, variable == "weight_percent_change_prewar")
   params <- list(
     # Most recent date

--- a/_organisation.qmd
+++ b/_organisation.qmd
@@ -1,0 +1,108 @@
+<!-- Organisation-level data -->
+
+```{r, include=FALSE}
+## Load Data
+data_filtered <- data |> 
+  filter(organisation == params$organisation)
+# split data into summary by recent 72h, or by daily cross-section
+data_filtered_current <- data_filtered |> 
+  filter(is.na(date))
+data_filtered_timeseries <- data_filtered |> 
+  filter(!is.na(date))
+
+insights <- generate_key_insights(data_filtered_current, 
+                                  strata = "overall")
+```
+
+::: {.callout-tip collapse="false" title="Key insights"}
+- Data updated as of **`r insights$latest_date`**
+- Recent data from **`r insights$cohort_size_current` participants** (**`r insights$cohort_percent_currently_participating`%** of all enrolled participants)
+- Median change of **`r insights$median_change`%** compared to pre-war weight (with a typical range of `r insights$lower_change`% to `r insights$upper_change`%)
+:::
+
+::: {.callout-tip collapse="false" title="Nutritional status"}
+
+::: {.panel-tabset} 
+
+### Weight change
+
+::: {.panel-tabset} 
+
+#### Current status
+
+```{r}
+weight_variable <- "weight_percent_change_prewar"
+data_filtered_current_weight <- data_filtered_current |> 
+  filter(variable == weight_variable) |> 
+  pivot_wider(names_from = stat, values_from = value) 
+# plot_current_summary_stats(
+#   data = data_filtered_current_weight,
+#   strata = "overall"
+#   ) |> 
+#   ggplotly()
+w_kg <- data_filtered_current_weight |> 
+  filter(group %in% c("sex", "agegroup", "governorate", "children_feeding")) |> 
+  mutate(group = as.character(group)) |> 
+  highlight_key(~ group) 
+
+w_kg_plot <- w_kg |> 
+  ggplot(aes(y = group, group = group)) +
+  geom_point(aes(x = median, shape = group, col = label),
+             position = position_dodge(width = 0.5), 
+             show.legend = F, size = 3) +
+    geom_linerange(aes(xmin = q1, xmax = q3,
+                       col = label),
+             position = position_dodge(width = 0.5), 
+             show.legend = F, linewidth = 3, alpha = 0.8)
+
+w_kg_plot <- ggplotly(w_kg_plot) |> 
+   highlight(on = "plotly_selected", dynamic = TRUE, selectize = TRUE)
+
+w_kg_plot
+```
+
+Summary of most recent data provided by participants reporting over the last 3 days. Current weight in kilograms (kg) and BMI (body mass index), in addition to percent change in weight and BMI from pre-war levels (before October 8th 2023) are shown on the x-axes of the panels. Negative values of percent change indicate weight loss, i.e. ‘-20%’ indicates an average loss of 20% of weight or BMI.
+
+#### Trends over time
+
+::: {.panel-tabset}
+
+TBD
+
+:::
+
+<!--- close weight tab --->
+
+:::
+
+### BMI
+
+::: {.panel-tabset}
+
+#### Overall
+
+```{r}
+print("plot overall BMI")
+```
+
+#### By demographic
+
+::: {.panel-tabset} 
+
+##### Sex
+
+```{r}
+print("plot by sex BMI")
+```
+
+##### Age
+
+```{r}
+print("plot by sex BMI")
+```
+
+:::
+
+::: 
+
+:::

--- a/index.qmd
+++ b/index.qmd
@@ -1,16 +1,16 @@
 ---
-title: Dashboard
+title: ""
 format: 
-  dashboard:
-    scrolling: true
+  html:
     include-in-header:
       text: |
             <script src="lshtm.js"></script>
     css: "styles.css"
     fig-format: svg
-  #html:
-  #  page-layout: custom
-toc: true
+    page-layout: custom
+    anchor-sections: true
+    smooth-scroll: true
+toc: false
 execute: 
   echo: false
 ---
@@ -29,19 +29,12 @@ datadict <- readRDS("data/data_dictionary.RDS")
 
 ## Load Data RDS
 data <- readRDS("data/public/summary-stats.RDS")
+data <- list_rbind(map(data, ~ list_rbind(.x))) |> 
+  filter(!grepl("-", group))
 
-options <- c("sex", "agegroup", "governorate", "role")
-# Generate all non-empty combinations
-strata <- unlist(
-  #lapply(1:length(options), function(k) {
-  lapply(1:2, function(k) {
-    combn(sort(options), k, FUN = function(x) paste(x, collapse = "-"))
-  })
-)
-# Add 'Overall' as default/fallback
-strata <- c("Overall", strata)
-
-organisations <- names(data)[2:length(data)]
+params <- list("organisation" = NULL,
+               "strata" = c("overall", 
+                            "sex", "agegroup", "governorate", "role", "children_feeding"))
 
 ## Source plotting scripts
 source(here("R", "data-analysis/generate_key_insights.R"))
@@ -51,318 +44,57 @@ source(here("R", "data-analysis/plot_current_summary_stats.R"))
 source(here("R", "data-analysis/plot_time_series_statistics.R"))
 source(here("R", "data-analysis/plot_bmicategory_proportions_time_series.R"))
 source(here("R", "data-analysis/ggplot_theme.R"))
-
 ```
 
 <!-- Global sidebar -->
 
-# {.sidebar}
+:::: {.columns}
 
-This project provides real-time information on the nutritional status of humanitarian staff in Gaza. Our aim is to inform humanitarian decision-making, advocacy, and diplomatic action to improve the lives of the affected population. We are developing this project during a rapidly changing situation: please interpret results with caution. [Find out more](./about)
+::: {.column width="25%"}
 
-::: {.callout-caution title="Join us"}
-We are actively seeking participants to support the project, and welcome new collaborations with humanitarian organisations. [**Get involved**](./contact)
+::: {.callout-note collapse="false" title="Dashboard"}
+This project provides real-time information on the **nutritional status of humanitarian staff in Gaza**. Our aim is to inform humanitarian decision-making, advocacy, and diplomatic action to improve the lives of the affected population. We are developing this project during a rapidly changing situation: **please interpret results with caution**. [**Read more**](./about){.btn .btn-outline-primary .btn role="button"} 
 :::
 
-<!-- Add data filter
- - todo: change to pandoc format
- - todo: fill options automatically or wrap in function
--->
-<div class="lshtm_widget_filter">
-  <p><strong>Stratify data by</strong></p>
-  <div class="filter_content">
-  <fieldset>
-    <!--<legend>Stratify data by</legend>-->
-    <label>
-      <input type="checkbox" name="data_filter" value="sex">
-      Sex
-    </label><br>
-    <label>
-      <input type="checkbox" name="data_filter" value="agegroup">
-      Age
-    </label><br>
-    <label>
-      <input type="checkbox" name="data_filter" value="governorate">
-      Location
-    </label><br>
-    <label>
-      <input type="checkbox" name="data_filter" value="role">
-      Role
-    </label>
-  </fieldset>
-</div>
-</div>
+::: {.callout-caution collapse="false" title="Join us"}
+We are actively seeking participants to support the project, and welcome humanitarian staff to get in touch. [**Join us**](./contact){.btn .btn-outline-success .btn role="button"} 
+:::
 
-<!-- Dashboard page 1 -->
+:::
 
 
-# All Participants
+::: {.column width="75%"}
 
-```{r filter_all, include=FALSE}
-data_filtered <- data$all
-# split data into current 72h summary, or full timeseries
-data_filtered_current <- map(data_filtered,
-                             ~ filter(.x, is.na(date)))
-data_filtered_timeseries <- map(data_filtered,
-                             ~ filter(.x, !is.na(date)))
+::: {.panel-tabset}
 
-params <- generate_key_insights(data_filtered_current, strata = "Overall") # TODO iterate over strata to match other chunks
+
+## **All participants**
+
+```{r}
+params$organisation <- "all"
 ```
 
-## Row
-
-::: {.card fill="false" title="Key insights"}
-- Data updated as of **`r params$latest_date`**
-- Recent data from **`r params$cohort_size_current` participants** (**`r params$cohort_percent_currently_participating`%** of all enrolled participants)
-- Median change of **`r params$median_change`%** compared to pre-war weight (with a typical range of `r params$lower_change`% to `r params$upper_change`%)
-:::
-
-## Row
-
-::: {.card .current_summary_card .lshtm_widget title="Current summary" fill = "false"}
-<!-- Can't set ID or data-widget value in this pandoc-card element, so need another nested div... -->
-<div class="lshtm_widget_identifier" id="current_summary">
-```{r plot-current-summary, results="asis"}
-#| fig-width: 8
-#| fig-asp: 0.4
-#| fig-align: center
-for(i in strata) {
-  # show the first stratum (overall) by default
-  visible_class = ifelse(i == strata[1], "visible", "")
-  cat(glue::glue("<div class='lshtm_widget_content {visible_class}' id='current_summary_{i}'>"))
-  
-  print(
-    plot_current_summary_stats(
-      data = data_filtered_current,
-      strata = i
-    )
-  )
-  cat('</div>')
-}
-```
-</div>
-Summary of most recent data provided by participants reporting over the last 3 days. Current weight in kilograms (kg) and [BMI (body mass index)](https://www.cdc.gov/bmi/adult-calculator/index.html?), in addition to percent change in weight and BMI from pre-war levels (before October 8th 2023) are shown on the x-axes of the panels. Negative values of percent change indicate weight loss, i.e. '-20%' indicates an average loss of 20% of weight or BMI.
-:::
-
-## Row
-<!-- Create div for trend over time -->
-::: {.card .trend_time_card .lshtm_widget title="Recent trends" fill = "false"}
-<!-- Can't set ID or data-widget value in this pandoc-card element, so need another nested div... -->
-<div class="lshtm_widget_identifier" id="trend_over_time">
-```{r plot-trends-weight, results="asis"}
-#| fig-width: 8
-#| fig-asp: 1.3
-#| fig-align: center
-for(i in strata) {
-  # show the first stratum (overall) by default
-  visible_class = ifelse(i == strata[1], "visible", "")
-  cat(glue::glue("<div class='lshtm_widget_content {visible_class}' id='trend_over_time_{i}'>"))
-  
-  print(
-   plot_time_series_statistics(
-      data = data_filtered_timeseries,
-      strata = i
-    )
-  )
-  cat('</div>')
-}
-```
-</div>
-Trends over time in absolute values of weight in kilograms (kg) and [BMI (body mass index)](https://www.cdc.gov/bmi/adult-calculator/index.html?) and percent change in weight and BMI from pre-war levels (before October 8th 2023) since the beginning of the project. Solid and dashed lines indicate mean and median values respectively for each demographic stratification. The coloured shaded regions show the boundaries of the interquartile range.
-:::
-
-## Row
-<!-- Create div for trend over time -->
-::: {.card .trend_bmi_card .lshtm_widget title="% Participants by BMI category" fill = "false"}
-<!-- Can't set ID or data-widget value in this pandoc-card element, so need another nested div... -->
-<div class="lshtm_widget_identifier" id="trends_bmi">
-```{r plot-trends-bmi, results="asis"}
-#| fig-width: 8
-#| fig-asp: 1
-#| fig-align: center
-for(i in strata) {
-  # show the first stratum (overall) by default
-  visible_class = ifelse(i == strata[1], "visible", "")
-  cat(glue::glue("<div class='lshtm_widget_content {visible_class}' id='trends_bmi_{i}'>"))
-  
-  print(
-     plot_bmicategory_proportions_time_series(
-     data = data_filtered_timeseries,
-     strata = i
-    )
-  )
-  cat('</div>')
-}
-```
-</div>
-Trends over time of proportion of staff with BMI in different [WHO categories](https://www.who.int/data/gho/data/themes/topics/topic-details/GHO/body-mass-index): underweight <18.5, normal 18.50 – 24.99, overweight ≥ 25, obese ≥ 30. Calculated as the number of measurements per day that fall in each category, divided by the total number of measurements that day.
-:::
-
-## Row
-
-::: {.card fill="false" .lshtm_widget title="Study participation"}
-<div class="lshtm_widget_identifier" id="participants_over_time">
-```{r plot-participants-over-time, results="asis"}
-#| fig-width: 7
-#| fig-asp: 0.5
-#| fig-align: center
-for(i in strata) {
-  # show the first stratum (overall) by default
-  visible_class = ifelse(i == strata[1], "visible", "")
-  cat(glue::glue("<div class='lshtm_widget_content {visible_class}' id='participants_over_time_{i}'>"))
-  
-  print(
-    plot_participants_over_time(
-      data = data_filtered_timeseries,
-      strata = i
-    )
-  )
-  cat('</div>')
-}
-```
-</div>
-:::
+{{< include _organisation.qmd >}}
 
 
+## **UNRW**
 
-<!-- ------------------------ Organisation tabs --------------------------- -->
-
-
-# Save the Children International
-```{r filter_stc, include=FALSE}
-data_filtered <- data$`Save the Children International`
-# split data into current 72h summary, or full timeseries
-data_filtered_current <- map(data_filtered,
-                             ~ filter(.x, is.na(date)))
-data_filtered_timeseries <- map(data_filtered,
-                             ~ filter(.x, !is.na(date)))
-
-params <- generate_key_insights(data_filtered_current, strata = "Overall") # TODO iterate over strata to match other chunks
+```{r}
+params$organisation <- "UNRW"
 ```
 
+{{< include _organisation.qmd >}}
 
-::: {.card fill="false" title="Key insights"}
-- Data updated as of **`r params$latest_date`**
-- Recent data from **`r params$cohort_size_current` participants** (**`r params$cohort_percent_currently_participating`%** of all enrolled participants)
-- Median change of **`r params$median_change`%** compared to pre-war weight (with a typical range of `r params$lower_change`% to `r params$upper_change`%)
-:::
+## **Save the Children International**
 
-
-::: {.card .current_summary_card .lshtm_widget title="Current summary" fill = "false"}
-<!-- Can't set ID or data-widget value in this pandoc-card element, so need another nested div... -->
-<div class="lshtm_widget_identifier" id="current_summary">
-```{r plot-current-summary_stc, results="asis"}
-#| fig-width: 8
-#| fig-asp: 0.4
-#| fig-align: center
-for(i in strata) {
-  # show the first stratum (overall) by default
-  visible_class = ifelse(i == strata[1], "visible", "")
-  cat(glue::glue("<div class='lshtm_widget_content {visible_class}' id='current_summary_{i}'>"))
-  
-  print(
-    plot_current_summary_stats(
-      data = data_filtered_current,
-      strata = i
-    )
-  )
-  cat('</div>')
-}
+```{r}
+params$organisation <- "SCI"
 ```
-</div>
-Summary of most recent data provided by participants reporting over the last 3 days. Current weight in kilograms (kg) and [BMI (body mass index)](https://www.cdc.gov/bmi/adult-calculator/index.html?), in addition to percent change in weight and BMI from pre-war levels (before October 8th 2023) are shown on the x-axes of the panels. Negative values of percent change indicate weight loss, i.e. '-20%' indicates an average loss of 20% of weight or BMI.
-:::
 
-
-<!-- Create div for trend over time -->
-::: {.card .trend_time_card .lshtm_widget title="Recent trends" fill = "false"}
-<!-- Can't set ID or data-widget value in this pandoc-card element, so need another nested div... -->
-<div class="lshtm_widget_identifier" id="trend_over_time">
-```{r plot-trends-weight_stc, results="asis"}
-#| fig-width: 8
-#| fig-asp: 1.5
-#| fig-align: center
-for(i in strata) {
-  # show the first stratum (overall) by default
-  visible_class = ifelse(i == strata[1], "visible", "")
-  cat(glue::glue("<div class='lshtm_widget_content {visible_class}' id='trend_over_time_{i}'>"))
-  
-  print(
-    plot_time_series_statistics(
-      data = data_filtered_timeseries,
-      strata = i
-    )
-  )
-  cat('</div>')
-}
-```
-</div>
-Trends over time in absolute values of weight in kilograms (kg) and [BMI (body mass index)](https://www.cdc.gov/bmi/adult-calculator/index.html?) and percent change in weight and BMI from pre-war levels (before October 8th 2023) since the beginning of the project. Solid and dashed lines indicate mean and median values respectively for each demographic stratification. The coloured shaded regions show the boundaries of the interquartile range.
-:::
-
-
-<!-- Create div for trend over time -->
-::: {.card .trend_bmi_card .lshtm_widget title="% Participants by BMI category" fill = "false"}
-<!-- Can't set ID or data-widget value in this pandoc-card element, so need another nested div... -->
-<div class="lshtm_widget_identifier" id="trends_bmi">
-```{r plot-trends-bmi_stc, results="asis"}
-#| fig-width: 8
-#| fig-asp: 1
-#| fig-align: center
-for(i in strata) {
-  # show the first stratum (overall) by default
-  visible_class = ifelse(i == strata[1], "visible", "")
-  cat(glue::glue("<div class='lshtm_widget_content {visible_class}' id='trends_bmi_{i}'>"))
-  
-  print(
-     plot_bmicategory_proportions_time_series(
-     data = data_filtered_timeseries,
-     strata = i
-    )
-  )
-  cat('</div>')
-}
-```
-</div>
-Trends over time in % staff with BMI in different [WHO categories](https://www.who.int/data/gho/data/themes/topics/topic-details/GHO/body-mass-index): underweight <18.5, normal 18.50 – 24.99, overweight ≥ 25, obese ≥ 30. Calculated as the number of measurements per day that fall in each category, divided by the total number of measurements that day.
+{{< include _organisation.qmd >}}
 
 :::
 
-## Row
-
-::: {.card fill="false" .lshtm_widget title="Study participation"}
-<div class="lshtm_widget_identifier" id="participants_over_time">
-```{r plot-participants-over-time-stc, results="asis"}
-#| fig-width: 7
-#| fig-asp: 0.5
-#| fig-align: center
-for(i in strata) {
-  # show the first stratum (overall) by default
-  visible_class = ifelse(i == strata[1], "visible", "")
-  cat(glue::glue("<div class='lshtm_widget_content {visible_class}' id='participants_over_time_{i}'>"))
-  
-  print(
-    plot_participants_over_time(
-      data = data_filtered_timeseries,
-      strata = i
-    )
-  )
-  cat('</div>')
-}
-```
-</div>
 :::
 
-
-
-
-
-# UNRWA
-
-::: {.callout-caution title="Coming Soon"}
-Data collection with the [**UN Relief Workers Agency (UNRWA)**](https://www.unrwa.org/) is starting very soon. Check back here shortly for results from this organisation.
-:::
-
-
-
-
+::::


### PR DESCRIPTION
DRAFT - work in progress / using a PR to share code and updates to discuss.

Aims:

- Use a single template for all organisations to avoid duplicated code
- Within this template, call `ggplot` or equivalent directly, to enable interactive plots rather than printing results `as-is` in a quarto code chunk.

Key changes:

- Merged the duplicated code for each organisation into a single template: `_organisation.qmd . This is called for each organisation in `index.qmd`, and displayed as a separate top-level tab.
- Below this i've suggested ideas for using tabs for the plots for each organisation: as discussed, using the original dashboard layout which had a sequence of tabs for Weight - BMI - Modelled change
- Drops the manual switch for toggling stratification as hoping to find a way to do this via plotly, but certainly something to put back if not
- Note the `index.qmd` now renders to html, not 'quarto dashboard' (as this was a bit annoying for handling tabs) - i've tried to recreate the same layout with the sidepanel etc.

Bear in mind: rendering this currently looks a bit odd (there are no plots) - the idea is to get the right sections in place where ggplot calls can be slotted in directly, and then neater formatting after that.

To do:

- Think about overall structure of the dashboard for tabs beneath the level of organisation (eg: weight > current / over time; bmi > current / over time) 
- Figure out how / where to put stratified data. 
   - I think interactive visualisation is doable either 
      - on a single plotly, using a long dataframe and a dropdown to toggle between groups (could look quite long and messy, but feasible); or 
      - by using a for loop to create a tab for each group.
   - To avoid overwhelm I imagine this will need to only include plots for the 5 key factors by organisation. 
   - Possibly only the "most recent" summary (or an all-time summary) - i.e. not creating stratified plots over time - as we aren't expecting that much data in the ongoing follow up data collection, compared to keeping a focus on the participants at baseline.