### PR TITLE
Output a dataframe, not a list

### DIFF
--- a/R/data-analysis/generate_key_insights.R
+++ b/R/data-analysis/generate_key_insights.R
@@ -16,7 +16,7 @@
 
 
 generate_key_insights <- function(data, strata) {
-  data <- data[[tolower(strata)]]
+  data <- filter(data, group == tolower(strata))
   data <- filter(data, variable == "weight_percent_change_prewar")
   params <- list(
     # Most recent date

--- a/R/data-analysis/plot_bmicategory_proportions_time_series.R
+++ b/R/data-analysis/plot_bmicategory_proportions_time_series.R
@@ -31,7 +31,7 @@ pacman::p_load(
 plot_bmicategory_proportions_time_series <- function(data, strata = "Overall"){
 
   # Filter data for the selected option
-  data_filter <- data[[tolower(strata)]] |>
+  data_filter <- filter(data, group == tolower(strata)) |>
     # filter out the duplicate "current" records
     dplyr::filter(date <= Sys.Date()) %>%
     #dplyr::filter(!sex == "other/prefer not to share") %>%

--- a/R/data-analysis/plot_current_summary_stats.R
+++ b/R/data-analysis/plot_current_summary_stats.R
@@ -30,7 +30,7 @@ pacman::p_load(
 plot_current_summary_stats <- function(data, strata = "Overall"){
 
   # Filter data for the selected option
-  data_filter <- data[[tolower(strata)]] |>
+  data_filter <- filter(data, group == tolower(strata)) |>
     pivot_wider(names_from = stat, values_from = value) %>%
     dplyr::filter(!is.na(mean)) |>
     filter(!grepl("_firstmeasurement", variable))

--- a/R/data-analysis/plot_participants_over_time.R
+++ b/R/data-analysis/plot_participants_over_time.R
@@ -28,13 +28,13 @@ pacman::p_load(
 plot_participants_over_time <- function(data, strata = "Overall"){
 
   # Filter data for the selected option
-  data_filter <- data[[tolower(strata)]] |>
+  data_filter <- filter(data, group == tolower(strata)) |>
     pivot_wider(names_from = stat, values_from = value) %>%
     dplyr::filter(!is.na(mean)) |>
     filter(variable == "weight") |>
-    full_join(expand.grid(list(date = as.Date(min(data[[tolower(strata)]]$date) - 1),
+    full_join(expand.grid(list(date = as.Date(min(filter(data, group == tolower(strata))$date) - 1),
                                cohort_n = 0,
-                               label = unique(data[[tolower(strata)]]$label))))
+                               label = unique(filter(data, group == tolower(strata))$label))))
 
   if (strata == "Overall") {
     # Generate plot

--- a/R/data-analysis/plot_time_series_statistics.R
+++ b/R/data-analysis/plot_time_series_statistics.R
@@ -30,7 +30,7 @@ pacman::p_load(
 plot_time_series_statistics <- function(data, strata = "Overall"){
 
   # Filter data for the selected option
-  data_filter <- data[[tolower(strata)]] |>
+  data_filter <- filter(data, group == tolower(strata)) |>
     # filter out the duplicate "current" records
     dplyr::filter(date <= Sys.Date()) %>%
     #dplyr::filter(!sex == "other/prefer not to share") %>%

--- a/R/data-pipeline/2-data_aggregation.R
+++ b/R/data-pipeline/2-data_aggregation.R
@@ -108,9 +108,6 @@ clean_aggregated_data <- function(summary_list, latest_date) {
     mutate(group = str_replace_all(group, "date-organisation-", "")) |>
     mutate(group = str_replace_all(group, "date-", "")) |>
     dplyr::select(-overall)
-  org_split <- split(org_split, org_split$organisation)
-  org_split <- map(org_split,
-                   ~ split(., .$group))
 
   return(org_split)
 }

--- a/index.qmd
+++ b/index.qmd
@@ -99,15 +99,13 @@ We are actively seeking participants to support the project, and welcome new col
 # All Participants
 
 ```{r filter_all, include=FALSE}
-data_filtered <- data$all
+data_filtered <- filter(data, organisation == "all")
 # split data into current 72h summary, or full timeseries
 # Hi I am commenting this out because it doesn't match the data structure
 # This code is written with the indication that a change was introduced to the data analysis pipeline that gets the
 # 72 hour summary and puts it into the spreadsheet as date = NA
-data_filtered_current <- map(data_filtered,
-                             ~ filter(.x, date == max(date, na.rm=TRUE))) # Temporary fix bc the data from the pipeline isnt' matching atm
-data_filtered_timeseries <- map(data_filtered,
-                             ~ filter(.x, !is.na(date)))
+data_filtered_current <- filter(data_filtered, date == max(date, na.rm=TRUE)) # Temporary fix bc the data from the pipeline isnt' matching atm
+data_filtered_timeseries <- filter(data_filtered, !is.na(date))
 
 params <- generate_key_insights(data_filtered_current, strata = "Overall") # TODO iterate over strata to match other chunks
 ```
@@ -234,15 +232,13 @@ for(i in strata) {
 # Save the Children International
 
 ```{r filter_stc, include=FALSE}
-data_filtered <- data$`Save the Children International`
+data_filtered <- filter(data, organisation == "Save the Children International")
 # split data into current 72h summary, or full timeseries
 # Hi I am commenting this out because it doesn't match the data structure
 # This code is written with the indication that a change was introduced to the data analysis pipeline that gets the
 # 72 hour summary and puts it into the spreadsheet as date = NA
-data_filtered_current <- map(data_filtered,
-                             ~ filter(.x, date == max(date, na.rm = TRUE))) # Temporary fix bc the data from the pipeline isnt' matching atm
-data_filtered_timeseries <- map(data_filtered,
-                             ~ filter(.x, !is.na(date)))
+data_filtered_current <- filter(data_filtered, date == max(date, na.rm=TRUE)) # Temporary fix bc the data from the pipeline isnt' matching atm
+data_filtered_timeseries <- filter(data_filtered, !is.na(date))
 
 params <- generate_key_insights(data_filtered_current, strata = "Overall") # TODO iterate over strata to match other chunks
 ```
@@ -369,15 +365,13 @@ for(i in strata) {
 # UN Relief Workers Agency (UNRWA)
 
 ```{r filter_unrwa, include=FALSE}
-data_filtered <- data$UNRWA
+data_filtered <- filter(data, organisation == "UNRWA")
 # split data into current 72h summary, or full timeseries
 # Hi I am commenting this out because it doesn't match the data structure
 # This code is written with the indication that a change was introduced to the data analysis pipeline that gets the
 # 72 hour summary and puts it into the spreadsheet as date = NA
-data_filtered_current <- map(data_filtered,
-                             ~ filter(.x, date == max(date, na.rm=TRUE))) # Temporary fix bc the data from the pipeline isnt' matching atm
-data_filtered_timeseries <- map(data_filtered,
-                             ~ filter(.x, !is.na(date)))
+data_filtered_current <- filter(data_filtered, date == max(date, na.rm=TRUE)) # Temporary fix bc the data from the pipeline isnt' matching atm
+data_filtered_timeseries <- filter(data_filtered, !is.na(date))
 
 params <- generate_key_insights(data_filtered_current, strata = "Overall") # TODO iterate over strata to match other chunks
 ```


### PR DESCRIPTION
Updating the data pipeline at the back end to save the aggregated data as one big dataframe, rather than a list split by organisation. 

I think this makes making changes slightly friendlier in future and down the line will make plotly a bit easier too. 

I've updated the code wherever there are list selections by organisation, to replace them with calls to dplyr::filter. I've checked the site renders - everything runs fine and reproduces identical front end as we have now.