### PR TITLE
Fix BMI %

### DIFF
--- a/R/data-pipeline/1-data_cleaning.R
+++ b/R/data-pipeline/1-data_cleaning.R
@@ -128,7 +128,7 @@ clean_data <- function(base_data, fup_data) {
     mutate(
       weight_anomaly = case_when(
         !between(bmi, 10, 60) ~ TRUE,
-        weight_percent_change_previousmeasurement >= 10 ~ TRUE,
+        abs(weight_percent_change_previousmeasurement) >= 10 ~ TRUE,
         TRUE ~ FALSE)
     )
   # Set anomalous data to NA

--- a/R/data-pipeline/1-data_cleaning.R
+++ b/R/data-pipeline/1-data_cleaning.R
@@ -68,7 +68,6 @@ clean_data <- function(base_data, fup_data) {
     # remove records from before enrolment
     filter(date >= date_first_measurement)
 
-
 # Dates & cohort time -----------------------------------------------------
   observed_data <- id_date_grid |>
     dplyr::group_by(id) |>
@@ -93,8 +92,11 @@ clean_data <- function(base_data, fup_data) {
     dplyr::mutate(
       # BMI
       bmi = weight / (height/100)^2,
-      bmi_prewar = weight_prewar / (height/100)^2,
+      bmi_prewar = if_else(!is.na(weight),
+                           weight_prewar / (height/100)^2,
+                           NA),
       first_bmi_measurement = bmi[date == date_first_measurement],
+      latest_bmi_measurement = bmi[date == date_latest_measurement],
         # TODO add bmi categories here for tidiness
       # calculate change since enrolment
       weight_percent_change_firstmeasurement = ((weight - first_weight_measurement)/

--- a/R/data-pipeline/1-data_cleaning.R
+++ b/R/data-pipeline/1-data_cleaning.R
@@ -70,7 +70,7 @@ clean_data <- function(base_data, fup_data) {
 
 
 # Dates & cohort time -----------------------------------------------------
-  id_date_grid <- id_date_grid |>
+  observed_data <- id_date_grid |>
     dplyr::group_by(id) |>
     # time in cohort
     dplyr::mutate(participant_cumulative_days_enrolled = 1 + as.integer(
@@ -119,7 +119,7 @@ clean_data <- function(base_data, fup_data) {
                   bmi_percent_change_previousmeasurement) |>
     ungroup()
 
-  matched_data <- left_join(matched_data,
+ observed_data <- left_join(observed_data,
                             change_from_previous, by = c("id", "date"))
 
   # Data quality checks -----------------------------------------------------

--- a/R/data-pipeline/1-data_cleaning.R
+++ b/R/data-pipeline/1-data_cleaning.R
@@ -75,8 +75,14 @@ clean_data <- function(base_data, fup_data) {
     # time in cohort
     dplyr::mutate(participant_cumulative_days_enrolled = 1 + as.integer(
                     difftime(date, date_first_measurement, units = "days")),
-                  participant_cumulative_days_recorded = cumsum(!is.na(weight)),
-                  last_measurement = participant_cumulative_days_recorded == max(participant_cumulative_days_recorded, na.rm = TRUE) & !is.na(weight))
+                  participant_cumulative_days_recorded = cumsum(!is.na(weight))
+                  ) |>
+    # exclude participants with no weight measurement
+    filter(participant_cumulative_days_recorded > 0) |>
+    # add latest measure as separate variable
+    mutate(latest_measurement = participant_cumulative_days_recorded == max(participant_cumulative_days_recorded, na.rm = TRUE) & !is.na(weight),
+           date_latest_measurement = date[which(latest_measurement)],
+           weight_latest_mesurement = weight[which(latest_measurement)])
 
   #...............................................................................
   ### Add BMI and % wt change

--- a/R/data-pipeline/1-data_cleaning.R
+++ b/R/data-pipeline/1-data_cleaning.R
@@ -79,9 +79,9 @@ clean_data <- function(base_data, fup_data) {
     # exclude participants with no weight measurement
     filter(participant_cumulative_days_recorded > 0) |>
     # add latest measure as separate variable
-    mutate(latest_measurement = participant_cumulative_days_recorded == max(participant_cumulative_days_recorded, na.rm = TRUE) & !is.na(weight),
-           date_latest_measurement = date[which(latest_measurement)],
-           weight_latest_mesurement = weight[which(latest_measurement)])
+    mutate(last_measurement = participant_cumulative_days_recorded == max(participant_cumulative_days_recorded, na.rm = TRUE) & !is.na(weight),
+           date_last_measurement = date[which(last_measurement)],
+           weight_latest_mesurement = weight[which(last_measurement)])
 
   #...............................................................................
   ### Add BMI and % wt change
@@ -96,7 +96,7 @@ clean_data <- function(base_data, fup_data) {
                            weight_prewar / (height/100)^2,
                            NA),
       first_bmi_measurement = bmi[date == date_first_measurement],
-      latest_bmi_measurement = bmi[date == date_latest_measurement],
+      last_bmi_measurement = bmi[date == date_last_measurement],
         # TODO add bmi categories here for tidiness
       # calculate change since enrolment
       weight_percent_change_firstmeasurement = ((weight - first_weight_measurement)/
@@ -153,7 +153,7 @@ clean_data <- function(base_data, fup_data) {
   # BMI categories
   observed_data <- observed_data |>
     mutate(
-      bmi_category = case_when(
+      bmi_category_daily = case_when(
         bmi <= 10 ~ NA_character_,
         bmi < 18.5 ~ "underweight",
         bmi >= 18.5 & bmi < 25 ~ "normal",

--- a/R/data-pipeline/2-data_aggregation.R
+++ b/R/data-pipeline/2-data_aggregation.R
@@ -17,6 +17,8 @@ summarise_ids <- function(data, group_cols) {
     summarise(
       # participants enrolled ---
       cohort_id_enrolled = length(unique(id)),
+      # cohort new joiners ---
+      cohort_id_new = sum(date == date_first_measurement),
       # daily observations ---
       # number of recorded weights, denominator: cohort_n
       cohort_obs_recorded = sum(!is.na(weight)),
@@ -94,7 +96,7 @@ clean_aggregated_data <- function(summary_list, latest_date) {
   #   setting "date" to NA (as this is a summary of multiple dates),
   #   and marking these records with "current_summary_date" = latest date in the data
   summary_df <- summary_df |>
-    mutate(current_summary_date = as.Date(ifelse(date > Sys.Date(),
+    mutate(current_summary_date = as.Date(if_else(date > Sys.Date(),
                                          latest_date, date)),
            date = replace(date, date > Sys.Date(), NA))
 

--- a/R/data-pipeline/2-data_aggregation.R
+++ b/R/data-pipeline/2-data_aggregation.R
@@ -15,15 +15,12 @@ summarise_ids <- function(data, group_cols) {
   df_participants <- data |>
     group_by(across(all_of(group_cols))) |>
     summarise(
-      # cumulative participants enrolled ---
+      # participants enrolled ---
       cohort_id_enrolled = length(unique(id)),
-      # cohort new joiners ---
-      cohort_id_new = sum(date == date_first_measurement),
-      # cohort attrition (loss to follow up)
-      cohort_id_attrition = cohort_id_enrolled - cohort_id_new,
-      # number of recorded weights, denominator: cohort_id_enrolled
+      # daily observations ---
+      # number of recorded weights, denominator: cohort_n
       cohort_obs_recorded = sum(!is.na(weight)),
-      # missing weight among all enrolled, denominator: cohort_id_enrolled
+      # missing weight among all enrolled, denominator: cohort_n
       cohort_obs_missing = sum(is.na(weight)),
       # anomalous weight among recorded weights, denominator: cohort_obs_recorded
       cohort_obs_anomalous = sum(weight_anomaly),

--- a/R/data-pipeline/2-data_aggregation.R
+++ b/R/data-pipeline/2-data_aggregation.R
@@ -15,12 +15,15 @@ summarise_ids <- function(data, group_cols) {
   df_participants <- data |>
     group_by(across(all_of(group_cols))) |>
     summarise(
-      # participants enrolled ---
+      # cumulative participants enrolled ---
       cohort_id_enrolled = length(unique(id)),
-      # daily observations ---
-      # number of recorded weights, denominator: cohort_n
+      # cohort new joiners ---
+      cohort_id_new = sum(date == date_first_measurement),
+      # cohort attrition (loss to follow up)
+      cohort_id_attrition = cohort_id_enrolled - cohort_id_new,
+      # number of recorded weights, denominator: cohort_id_enrolled
       cohort_obs_recorded = sum(!is.na(weight)),
-      # missing weight among all enrolled, denominator: cohort_n
+      # missing weight among all enrolled, denominator: cohort_id_enrolled
       cohort_obs_missing = sum(is.na(weight)),
       # anomalous weight among recorded weights, denominator: cohort_obs_recorded
       cohort_obs_anomalous = sum(weight_anomaly),

--- a/R/data-pipeline/2-data_aggregation.R
+++ b/R/data-pipeline/2-data_aggregation.R
@@ -55,19 +55,20 @@ summarise_ids <- function(data, group_cols) {
 
   # proportions
   df_bmi_props <- data |>
+    filter(!is.na(bmi)) |>
     group_by(across(all_of(c(group_cols)))) |>
     pivot_longer(cols = contains("bmi_category"),
                  names_to = "bmi_period", values_to = "bmi_category") |>
     group_by(across(all_of(c(group_cols, "bmi_period", "bmi_category")))) |>
-    count(name = "value") |>
+    count(name = "bmi_category_count") |>
     # get % per category compared to all those measured in that group
     left_join(dplyr::select(df_participants,
                             all_of(c(group_cols, "cohort_obs_recorded")))) |>
-    mutate(value = value / cohort_obs_recorded * 100,
+    mutate(value = bmi_category_count / cohort_obs_recorded * 100,
            stat = "percent",
            variable = paste0(bmi_period, "_", bmi_category)) |>
     ungroup() |>
-    dplyr::select(all_of(c(group_cols, "value", "stat", "variable"))) |>
+    dplyr::select(all_of(c(group_cols, "bmi_category_count", "value", "stat", "variable"))) |>
     # TODO this might need updating to use the data dictionary, as nesting() only completes based on what's in the data
     complete(nesting(!!!syms(group_cols)), stat, variable, fill = list(value = 0))
 

--- a/R/data-pipeline/run-public-pipeline.R
+++ b/R/data-pipeline/run-public-pipeline.R
@@ -39,17 +39,16 @@ log$orgs <- unique(base_data$organisation)
 # Clean data -----
 data_id_daily <- clean_data(base_data, fup_data)
 
-# Current summary: use most recent observation from participants reporting in most recent x day window -----
-# filter to most recent observation for all participants
-# TODO consider adding a summary of this (ie. full cohort) in addition to 72h
-data_id_latest <- data_id_daily |>
+# Summaries ------------------------------------------------------------
+# filter to last recorded observation for all participants
+data_id_last <- data_id_daily |>
   filter(last_measurement)
 
-# current summary: only observations within most recent 72h window
+# set up dates: only observations within most recent 72h window
 latest_date <- as.Date(max(data_id_daily$date, na.rm = TRUE))
 recent_days <- seq.Date(from = latest_date - 3,
                         length.out = 4, by = "day")
-data_id_current <- data_id_latest |>
+data_id_current <- data_id_last |>
   filter(date %in% recent_days)
 log$recent_days <- count(data_id_current, date)
 


### PR DESCRIPTION
major changes:
- Fixes BMI % issue - it was double counting participants for pre-war values
- bmi_category_ variable name is consistent so it is easier in post-processing (bmi_category_daily_ / bmi_category_prewar)

minor changes:
- anomalies:
    -  found one participant who enrolled with only a pre-war weight value, no current weight - have set to exclude
    - fixed anomaly flag so measurement is anomalous if 
       - weight change more than +/- 10% in either direction (previously only flagged if +10%)
          - and this change occurred over < 5 days
       - note this hasn't been an issue so far but building in to catch in future
- adds variable for cohort new joiners to make attrition rate easier to check